### PR TITLE
Add whitenoise for static file serving

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -43,12 +43,14 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'tbdsms',
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -123,3 +125,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 
 STATIC_URL = '/static/'
+
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 dj-database-url==0.5.0
 Django==2.0.3
 pytz==2018.3
+whitenoise==3.3.1
 
 # TODO: These should eventually be moved to a requirements-dev.txt.
 pytest==3.4.2


### PR DESCRIPTION
This makes it easy for us to serve static files in production via [whitenoise](http://whitenoise.evans.io/en/stable/).
